### PR TITLE
Add idle timeout option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+* Add `sink.WithIdleTimeout` option to set an idle timeout.
+
 ## v0.5.2
 
 * Fixed `sink.WithAgent` option propagation.

--- a/sinker.go
+++ b/sinker.go
@@ -66,7 +66,6 @@ type Sinker struct {
 	// State
 	stats                   *Stats
 	requestActiveStartBlock uint64
-	lastMessageTime        	time.Time
 }
 
 func New(
@@ -371,7 +370,6 @@ func (s *Sinker) doRequest(
 ) {
 	req.StartCursor = activeCursor.String()
 	s.logger.Debug("launching substreams request", zap.Int64("start_block", req.StartBlockNum), zap.Stringer("cursor", activeCursor))
-	s.lastMessageTime = time.Now()
 	receivedMessage := false
 
 	stream, err := ssClient.Blocks(ctx, req, callOpts...)
@@ -408,7 +406,6 @@ func (s *Sinker) doRequest(
 		}
 
 		receivedMessage = true
-		s.lastMessageTime = time.Now()
 		MessageSizeBytes.AddInt(proto.Size(resp))
 
 		switch r := resp.Message.(type) {
@@ -604,11 +601,9 @@ func (s *Sinker) receiveWithTimeout(
 	case result := <-recvCh:
 		return result.resp, result.err, false
 	case <-timeoutCh:
-		idleTime := time.Since(s.lastMessageTime)
-		s.logger.Warn("no messages received within idle timeout period, forcing reconnection",
-			zap.Duration("idle_timeout", s.idleTimeout),
-			zap.Duration("time_since_last_message", idleTime))
-		return nil, retryable(fmt.Errorf("idle timeout exceeded: %v since last message", idleTime)), true
+		s.logger.Warn("stream.Recv() exceeded idle timeout, forcing reconnection",
+			zap.Duration("idle_timeout", s.idleTimeout))
+		return nil, retryable(fmt.Errorf("idle timeout exceeded: no message received within %v", s.idleTimeout)), true
 	}
 }
 

--- a/sinker.go
+++ b/sinker.go
@@ -580,24 +580,27 @@ type recvResult struct {
 func (s *Sinker) receiveWithTimeout(
 	stream grpc.ServerStreamingClient[pbsubstreamsrpc.Response],
 ) (*pbsubstreamsrpc.Response, error) {
-	recvCh := make(chan recvResult, 1)
+	if s.idleTimeout <= 0 {
+		return stream.Recv()
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), s.idleTimeout)
+	defer cancel()
 
-	// Start a goroutine to do the actual Recv call, which might block indefinitely
+	recvCh := make(chan recvResult, 1)
 	go func() {
 		resp, err := stream.Recv()
-		recvCh <- recvResult{resp, err}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+			recvCh <- recvResult{resp, err}
+		}
 	}()
-
-	// Only setup timeout if idle timeout is enabled
-	var timeoutCh <-chan time.Time
-	if s.idleTimeout > 0 {
-		timeoutCh = time.After(s.idleTimeout)
-	}
 
 	select {
 	case result := <-recvCh:
 		return result.resp, result.err
-	case <-timeoutCh:
+	case <-ctx.Done():
 		return nil, retryable(fmt.Errorf("idle timeout exceeded: no message received within %v", s.idleTimeout))
 	}
 }

--- a/sinker.go
+++ b/sinker.go
@@ -577,8 +577,6 @@ func receiveWithTimeout[R any](
 	stream interface{ Recv() (R, error) },
 	timeout time.Duration,
 ) (R, error) {
-	var zero R
-
 	if timeout <= 0 {
 		return stream.Recv()
 	}
@@ -605,6 +603,7 @@ func receiveWithTimeout[R any](
 	case result := <-recvCh:
 		return result.resp, result.err
 	case <-ctx.Done():
+		var zero R
 		return zero, fmt.Errorf("idle timeout exceeded: no message received within %v", timeout)
 	}
 }

--- a/sinker.go
+++ b/sinker.go
@@ -382,10 +382,7 @@ func (s *Sinker) doRequest(
 			s.logger.Debug("substreams waiting to receive message", zap.Stringer("cursor", activeCursor))
 		}
 
-		resp, err, timedOut := s.receiveWithTimeout(stream)
-		if timedOut {
-			return activeCursor, receivedMessage, err
-		}
+		resp, err := s.receiveWithTimeout(stream)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return activeCursor, receivedMessage, err
@@ -579,10 +576,10 @@ type recvResult struct {
 }
 
 // receiveWithTimeout receives a message from a stream with timeout handling.
-// returns the response, error, and a boolean indicating if the operation timed out.
+// returns the response and error (which may indicate a timeout).
 func (s *Sinker) receiveWithTimeout(
 	stream grpc.ServerStreamingClient[pbsubstreamsrpc.Response],
-) (*pbsubstreamsrpc.Response, error, bool) {
+) (*pbsubstreamsrpc.Response, error) {
 	recvCh := make(chan recvResult, 1)
 
 	// Start a goroutine to do the actual Recv call, which might block indefinitely
@@ -599,11 +596,9 @@ func (s *Sinker) receiveWithTimeout(
 
 	select {
 	case result := <-recvCh:
-		return result.resp, result.err, false
+		return result.resp, result.err
 	case <-timeoutCh:
-		s.logger.Warn("stream.Recv() exceeded idle timeout, forcing reconnection",
-			zap.Duration("idle_timeout", s.idleTimeout))
-		return nil, retryable(fmt.Errorf("idle timeout exceeded: no message received within %v", s.idleTimeout)), true
+		return nil, retryable(fmt.Errorf("idle timeout exceeded: no message received within %v", s.idleTimeout))
 	}
 }
 

--- a/sinker.go
+++ b/sinker.go
@@ -382,7 +382,7 @@ func (s *Sinker) doRequest(
 			s.logger.Debug("substreams waiting to receive message", zap.Stringer("cursor", activeCursor))
 		}
 
-		resp, err := s.receiveWithTimeout(stream)
+		resp, err := receiveWithTimeout(stream, s.idleTimeout)
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return activeCursor, receivedMessage, err
@@ -570,21 +570,24 @@ func retryable(err error) error {
 	return derr.NewRetryableError(err)
 }
 
-type recvResult struct {
-	resp *pbsubstreamsrpc.Response
-	err  error
-}
+// receiveWithTimeout is a generic helper to receive a message from any gRPC stream with timeout handling.
+// R represents the response type that will be returned by the stream.
+func receiveWithTimeout[R any](
+	stream interface{ Recv() (R, error) },
+	timeout time.Duration,
+) (R, error) {
+	var zero R
 
-// receiveWithTimeout receives a message from a stream with timeout handling.
-// returns the response and error (which may indicate a timeout).
-func (s *Sinker) receiveWithTimeout(
-	stream grpc.ServerStreamingClient[pbsubstreamsrpc.Response],
-) (*pbsubstreamsrpc.Response, error) {
-	if s.idleTimeout <= 0 {
+	if timeout <= 0 {
 		return stream.Recv()
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), s.idleTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+
+	type recvResult struct {
+		resp R
+		err  error
+	}
 
 	recvCh := make(chan recvResult, 1)
 	go func() {
@@ -601,7 +604,7 @@ func (s *Sinker) receiveWithTimeout(
 	case result := <-recvCh:
 		return result.resp, result.err
 	case <-ctx.Done():
-		return nil, retryable(fmt.Errorf("idle timeout exceeded: no message received within %v", s.idleTimeout))
+		return zero, fmt.Errorf("idle timeout exceeded: no message received within %v", timeout)
 	}
 }
 

--- a/sinker.go
+++ b/sinker.go
@@ -61,10 +61,12 @@ type Sinker struct {
 	livenessChecker LivenessChecker
 	extraHeaders    []string
 	agent           string
+	idleTimeout 	time.Duration
 
 	// State
 	stats                   *Stats
 	requestActiveStartBlock uint64
+	lastDataMessageTime     time.Time
 }
 
 func New(
@@ -369,6 +371,7 @@ func (s *Sinker) doRequest(
 ) {
 	req.StartCursor = activeCursor.String()
 	s.logger.Debug("launching substreams request", zap.Int64("start_block", req.StartBlockNum), zap.Stringer("cursor", activeCursor))
+	s.lastDataMessageTime = time.Time{}
 	receivedMessage := false
 
 	stream, err := ssClient.Blocks(ctx, req, callOpts...)
@@ -407,6 +410,17 @@ func (s *Sinker) doRequest(
 		switch r := resp.Message.(type) {
 		case *pbsubstreamsrpc.Response_Progress:
 			msg := r.Progress
+
+			if s.idleTimeout > 0 && !s.lastDataMessageTime.IsZero() {
+				idleTime := time.Since(s.lastDataMessageTime)
+				if idleTime > s.idleTimeout {
+					s.logger.Warn("no data messages received within idle timeout period, reconnecting",
+						zap.Duration("idle_timeout", s.idleTimeout),
+						zap.Duration("time_since_last_data", idleTime))
+					return activeCursor, receivedMessage, retryable(fmt.Errorf("idle timeout exceeded: %v since last data message", idleTime))
+				}
+			}
+
 			var totalProcessedBlocks uint64
 
 			latestEndBlockPerStage := make(map[uint32]uint64)
@@ -460,6 +474,8 @@ func (s *Sinker) doRequest(
 			if s.tracer.Enabled() {
 				s.logger.Debug("received response BlockScopedData", zap.Stringer("at", block), zap.String("module_name", moduleOutput.Name), zap.Int("payload_bytes", len(moduleOutput.MapOutput.Value)))
 			}
+
+			s.lastDataMessageTime = time.Now()
 
 			// We record our stats before the buffer action, so user sees state of "stream" and not state of buffer
 			s.stats.RecordBlock(block)

--- a/sinker.go
+++ b/sinker.go
@@ -66,7 +66,7 @@ type Sinker struct {
 	// State
 	stats                   *Stats
 	requestActiveStartBlock uint64
-	lastDataMessageTime     time.Time
+	lastMessageTime        	time.Time
 }
 
 func New(
@@ -371,7 +371,7 @@ func (s *Sinker) doRequest(
 ) {
 	req.StartCursor = activeCursor.String()
 	s.logger.Debug("launching substreams request", zap.Int64("start_block", req.StartBlockNum), zap.Stringer("cursor", activeCursor))
-	s.lastDataMessageTime = time.Time{}
+	s.lastMessageTime = time.Now()
 	receivedMessage := false
 
 	stream, err := ssClient.Blocks(ctx, req, callOpts...)
@@ -384,7 +384,10 @@ func (s *Sinker) doRequest(
 			s.logger.Debug("substreams waiting to receive message", zap.Stringer("cursor", activeCursor))
 		}
 
-		resp, err := stream.Recv()
+		resp, err, timedOut := s.receiveWithTimeout(stream)
+		if timedOut {
+			return activeCursor, receivedMessage, err
+		}
 		if err != nil {
 			if errors.Is(err, io.EOF) {
 				return activeCursor, receivedMessage, err
@@ -405,24 +408,14 @@ func (s *Sinker) doRequest(
 		}
 
 		receivedMessage = true
+		s.lastMessageTime = time.Now()
 		MessageSizeBytes.AddInt(proto.Size(resp))
 
 		switch r := resp.Message.(type) {
 		case *pbsubstreamsrpc.Response_Progress:
 			msg := r.Progress
 
-			if s.idleTimeout > 0 && !s.lastDataMessageTime.IsZero() {
-				idleTime := time.Since(s.lastDataMessageTime)
-				if idleTime > s.idleTimeout {
-					s.logger.Warn("no data messages received within idle timeout period, reconnecting",
-						zap.Duration("idle_timeout", s.idleTimeout),
-						zap.Duration("time_since_last_data", idleTime))
-					return activeCursor, receivedMessage, retryable(fmt.Errorf("idle timeout exceeded: %v since last data message", idleTime))
-				}
-			}
-
 			var totalProcessedBlocks uint64
-
 			latestEndBlockPerStage := make(map[uint32]uint64)
 			jobsPerStage := make(map[uint32]uint64)
 
@@ -474,8 +467,6 @@ func (s *Sinker) doRequest(
 			if s.tracer.Enabled() {
 				s.logger.Debug("received response BlockScopedData", zap.Stringer("at", block), zap.String("module_name", moduleOutput.Name), zap.Int("payload_bytes", len(moduleOutput.MapOutput.Value)))
 			}
-
-			s.lastDataMessageTime = time.Now()
 
 			// We record our stats before the buffer action, so user sees state of "stream" and not state of buffer
 			s.stats.RecordBlock(block)
@@ -583,6 +574,42 @@ func stageString(i uint32) string {
 
 func retryable(err error) error {
 	return derr.NewRetryableError(err)
+}
+
+type recvResult struct {
+	resp *pbsubstreamsrpc.Response
+	err  error
+}
+
+// receiveWithTimeout receives a message from a stream with timeout handling.
+// returns the response, error, and a boolean indicating if the operation timed out.
+func (s *Sinker) receiveWithTimeout(
+	stream grpc.ServerStreamingClient[pbsubstreamsrpc.Response],
+) (*pbsubstreamsrpc.Response, error, bool) {
+	recvCh := make(chan recvResult, 1)
+
+	// Start a goroutine to do the actual Recv call, which might block indefinitely
+	go func() {
+		resp, err := stream.Recv()
+		recvCh <- recvResult{resp, err}
+	}()
+
+	// Only setup timeout if idle timeout is enabled
+	var timeoutCh <-chan time.Time
+	if s.idleTimeout > 0 {
+		timeoutCh = time.After(s.idleTimeout)
+	}
+
+	select {
+	case result := <-recvCh:
+		return result.resp, result.err, false
+	case <-timeoutCh:
+		idleTime := time.Since(s.lastMessageTime)
+		s.logger.Warn("no messages received within idle timeout period, forcing reconnection",
+			zap.Duration("idle_timeout", s.idleTimeout),
+			zap.Duration("time_since_last_message", idleTime))
+		return nil, retryable(fmt.Errorf("idle timeout exceeded: %v since last message", idleTime)), true
+	}
 }
 
 var (

--- a/sinker.go
+++ b/sinker.go
@@ -409,8 +409,8 @@ func (s *Sinker) doRequest(
 		switch r := resp.Message.(type) {
 		case *pbsubstreamsrpc.Response_Progress:
 			msg := r.Progress
-
 			var totalProcessedBlocks uint64
+
 			latestEndBlockPerStage := make(map[uint32]uint64)
 			jobsPerStage := make(map[uint32]uint64)
 

--- a/sinker.go
+++ b/sinker.go
@@ -119,6 +119,7 @@ func New(
 		zap.Bool("infinite_retry", s.infiniteRetry),
 		zap.Bool("final_blocks_only", s.finalBlocksOnly),
 		zap.Bool("liveness_checker", s.livenessChecker != nil),
+		zap.Duration("idle_timeout", s.idleTimeout),
 	)
 
 	return s, nil

--- a/sinker_options.go
+++ b/sinker_options.go
@@ -95,7 +95,7 @@ func WithAgent(agent string) Option {
 }
 
 // WithIdleTimeout configures the [Sinker] instance to automatically
-// reconnect if no data messages are received within the specified duration.
+// reconnect if no gRPC messages are received within the specified duration.
 // Pass 0 to disable this feature (the default behavior).
 func WithIdleTimeout(timeout time.Duration) Option {
 	return func(s *Sinker) {

--- a/sinker_options.go
+++ b/sinker_options.go
@@ -1,6 +1,8 @@
 package sink
 
 import (
+	"time"
+
 	"github.com/cenkalti/backoff/v4"
 	"github.com/streamingfast/bstream"
 )
@@ -89,5 +91,14 @@ func WithExtraHeaders(headers []string) Option {
 func WithAgent(agent string) Option {
 	return func(s *Sinker) {
 		s.agent = agent
+	}
+}
+
+// WithIdleTimeout configures the [Sinker] instance to automatically
+// reconnect if no data messages are received within the specified duration.
+// Pass 0 to disable this feature (the default behavior).
+func WithIdleTimeout(timeout time.Duration) Option {
+	return func(s *Sinker) {
+		s.idleTimeout = timeout
 	}
 }


### PR DESCRIPTION
Helps control block timeout on the sink side for cases like this: https://github.com/streamingfast/substreams/issues/636

No change in behaviour if timeout wasn't explicitly set