### PR TITLE
fix(stats): stop progressBlockRate janitor in Stats.Close

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -84,6 +84,7 @@ func (s *Stats) Close() {
 	s.Shutdown(nil)
 	s.dataMsgRate.Stop()
 	s.undoMsgRate.Stop()
+	s.progressBlockRate.Stop()
 }
 
 type unsetBlockRef struct{}

--- a/stats_leak_test.go
+++ b/stats_leak_test.go
@@ -1,0 +1,38 @@
+package sink
+
+import (
+	"runtime"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+)
+
+// TestStatsClose_DoesNotLeakGoroutines verifies that Stats.Close stops every
+// background goroutine it spawned. Each AvgRate* helper constructed by
+// newStats runs a janitor goroutine; if Close forgets to stop any of them, a
+// long-running consumer that creates a fresh Stats per iteration will leak
+// goroutines monotonically (see redpandasink continuous mode).
+func TestStatsClose_DoesNotLeakGoroutines(t *testing.T) {
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	const iterations = 50
+	for i := 0; i < iterations; i++ {
+		s := newStats(zap.NewNop())
+		s.Close()
+	}
+
+	runtime.GC()
+	time.Sleep(200 * time.Millisecond)
+	growth := runtime.NumGoroutine() - baseline
+
+	// Two-goroutine tolerance covers ordinary scheduler/runtime noise. A bug
+	// where Close forgets one janitor produces growth ~= iterations, which is
+	// well outside the tolerance.
+	const tolerance = 2
+	if growth > tolerance {
+		t.Fatalf("Stats.Close leaks goroutines: grew by %d after %d iterations (tolerance=%d)", growth, iterations, tolerance)
+	}
+}


### PR DESCRIPTION
Stats.Close stopped dataMsgRate and undoMsgRate but never stopped progressBlockRate, leaking one janitor goroutine per Sinker lifecycle.

This is harmless for short-lived processes (the leaked goroutine is a process-lifetime constant) but causes monotonic goroutine growth in consumers that build a fresh *sink.Sinker per work cycle, e.g. sinkers operating in continuous mode with a sleep between collection intervals.

Adds TestStatsClose_DoesNotLeakGoroutines: the pre-fix code grows NumGoroutine() by exactly N after N Close() calls; the fix brings it back to ~0 within scheduler noise.